### PR TITLE
🔄 refactor: VIBEMUX_PANE_TOP_LEFT のデフォルト値を yazi → 空に変更

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@ vibemux list                       # アクティブなセッション一覧
 
 | 変数 | 説明 | デフォルト |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | `yazi` |
+| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | *(シェル)* |
 | `VIBEMUX_PANE_BOTTOM_LEFT` | 左下ペインのコマンド | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | 右ペインのコマンド | *(シェル)* |
 | `VIBEMUX_RIGHT_RATIO` | 右ペインの幅 (%) | `70` |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Customize pane commands via environment variables or a config file at `~/.config
 
 | Variable | Description | Default |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | Top-left pane command | `yazi` |
+| `VIBEMUX_PANE_TOP_LEFT` | Top-left pane command | *(shell)* |
 | `VIBEMUX_PANE_BOTTOM_LEFT` | Bottom-left pane command | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | Right pane command | *(shell)* |
 | `VIBEMUX_RIGHT_RATIO` | Right pane width (%) | `70` |

--- a/vibemux
+++ b/vibemux
@@ -4,7 +4,7 @@ set -euo pipefail
 VERSION="0.1.0"
 
 # ── Configuration ──────────────────────────────────────────────
-VIBEMUX_PANE_TOP_LEFT="${VIBEMUX_PANE_TOP_LEFT:-yazi}"
+VIBEMUX_PANE_TOP_LEFT="${VIBEMUX_PANE_TOP_LEFT:-}"
 VIBEMUX_PANE_BOTTOM_LEFT="${VIBEMUX_PANE_BOTTOM_LEFT:-lazygit}"
 VIBEMUX_PANE_RIGHT="${VIBEMUX_PANE_RIGHT:-}"
 VIBEMUX_RIGHT_RATIO="${VIBEMUX_RIGHT_RATIO:-70}"
@@ -37,7 +37,7 @@ Layout:
   └──────────┴─────────────────────┘
 
 Configuration (environment variables):
-  VIBEMUX_PANE_TOP_LEFT      Command for top-left pane     (default: yazi)
+  VIBEMUX_PANE_TOP_LEFT      Command for top-left pane     (default: shell)
   VIBEMUX_PANE_BOTTOM_LEFT   Command for bottom-left pane  (default: lazygit)
   VIBEMUX_PANE_RIGHT         Command for right pane        (default: shell)
   VIBEMUX_RIGHT_RATIO        Right pane width percentage    (default: 70)


### PR DESCRIPTION
## Summary
- `VIBEMUX_PANE_TOP_LEFT` のデフォルト値を `yazi` から空（シェル）に変更
- README.md / README.ja.md のデフォルト値表記を更新
- yazi を使いたいユーザーは `VIBEMUX_PANE_TOP_LEFT=yazi` で復元可能

## Test plan
- [ ] `vibemux new` でデフォルト左上ペインがシェルになることを確認
- [ ] `VIBEMUX_PANE_TOP_LEFT=yazi vibemux new` で yazi が起動することを確認
- [ ] `make check` が通ること

close https://github.com/hirokimry/vibemux/issues/32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * README とヘルプ表示で `VIBEMUX_PANE_TOP_LEFT` のデフォルト記載を `yazi` から「シェル（shell）」に変更しました。
* **修正**
  * 環境変数未設定時にトップ左ペインの起動コマンドが空になり、明示的に指定しない限りトップ左ペインはスキップされるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->