### PR TITLE
✨ feat: vibemux に $TMUX チェック追加（二重起動防止）

### DIFF
--- a/tests/test_vibemux.sh
+++ b/tests/test_vibemux.sh
@@ -71,8 +71,28 @@ echo
 
 # ── Invalid Directory ────────────────────────────────────────
 echo "[invalid directory]"
-assert_exit "new with nonexistent directory exits 1" 1 "$VIBEMUX" new testsession /nonexistent/path
-assert_output_contains "new with nonexistent dir shows error" "directory not found" "$VIBEMUX" new testsession /nonexistent/path
+
+# Unset TMUX to bypass the nested session check and test directory validation
+desc="new with nonexistent directory exits 1"
+actual=0
+(unset TMUX; "$VIBEMUX" new testsession /nonexistent/path) >/dev/null 2>&1 || actual=$?
+if [[ "$actual" -eq 1 ]]; then
+  echo "  PASS: $desc"
+  ((passed++))
+else
+  echo "  FAIL: $desc (expected exit 1, got $actual)"
+  ((failed++))
+fi
+
+desc="new with nonexistent dir shows error"
+output=$(unset TMUX; "$VIBEMUX" new testsession /nonexistent/path 2>&1) || true
+if echo "$output" | grep -qE "directory not found"; then
+  echo "  PASS: $desc"
+  ((passed++))
+else
+  echo "  FAIL: $desc (expected pattern 'directory not found' not found in output)"
+  ((failed++))
+fi
 echo
 
 # ── Attach Nonexistent Session ───────────────────────────────
@@ -84,6 +104,45 @@ echo
 echo "[env var defaults]"
 assert_output_contains "usage shows VIBEMUX_PANE_TOP_LEFT" "VIBEMUX_PANE_TOP_LEFT" "$VIBEMUX" help
 assert_output_contains "usage shows VIBEMUX_CONFIG" "VIBEMUX_CONFIG" "$VIBEMUX" help
+echo
+
+# ── Nested tmux session detection ────────────────────────────
+echo "[nested tmux detection]"
+
+# Test: TMUX set → new should fail with exit 1
+desc="new inside tmux session exits 1"
+actual=0
+TMUX=fake_tmux_session "$VIBEMUX" new testsession >/dev/null 2>&1 || actual=$?
+if [[ "$actual" -eq 1 ]]; then
+  echo "  PASS: $desc"
+  ((passed++))
+else
+  echo "  FAIL: $desc (expected exit 1, got $actual)"
+  ((failed++))
+fi
+
+# Test: TMUX set → new should show error message
+desc="new inside tmux session shows error message"
+output=$(TMUX=fake_tmux_session "$VIBEMUX" new testsession 2>&1) || true
+if echo "$output" | grep -q "already inside a tmux session"; then
+  echo "  PASS: $desc"
+  ((passed++))
+else
+  echo "  FAIL: $desc (expected 'already inside a tmux session' in output)"
+  ((failed++))
+fi
+
+# Test: TMUX unset → new should not fail due to TMUX check
+# (it will fail for other reasons like no tmux server, but not the TMUX check)
+desc="new without TMUX does not show nested session error"
+output=$(unset TMUX; "$VIBEMUX" new testsession 2>&1) || true
+if echo "$output" | grep -q "already inside a tmux session"; then
+  echo "  FAIL: $desc (got nested session error when TMUX is unset)"
+  ((failed++))
+else
+  echo "  PASS: $desc"
+  ((passed++))
+fi
 echo
 
 # ── Unknown Subcommand ───────────────────────────────────────

--- a/vibemux
+++ b/vibemux
@@ -64,6 +64,9 @@ cmd_new() {
   local session="$1"
   local dir="${2:-.}"
 
+  # Prevent nested tmux sessions
+  [[ -n "${TMUX:-}" ]] && die "already inside a tmux session (nested sessions are not supported)"
+
   dir="$(cd "$dir" 2>/dev/null && pwd)" || die "directory not found: ${2:-.}"
 
   tmux has-session -t "$session" 2>/dev/null && die "session '$session' already exists (use 'vibemux attach $session')"


### PR DESCRIPTION
## Summary
- `vibemux new` 実行時に `$TMUX` 環境変数をチェックし、tmux セッション内からの実行を検知
- ネストされたセッションの作成を防止し、エラーメッセージを表示して終了
- テストケースを追加（TMUX 設定時の検知、未設定時の正常動作）

## Test plan
- [ ] tmux セッション内で `vibemux new` を実行するとエラーで終了すること
- [ ] tmux セッション外で `vibemux new` が正常に動作すること
- [ ] `make check` が通ること

close https://github.com/hirokimry/vibemux/issues/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 既存のtmuxセッション内からの新規ワークスペース作成を拒否する機能を追加しました。

* **テスト**
  * ネストされたtmux検出をバイパスする無効なディレクトリテストを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->