### PR TITLE
📖 docs: README.md に並列時の使い方ガイド追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,31 @@ make check         # lint + tests をローカル実行
 - [tmux](https://github.com/tmux/tmux) (>= 3.0)
 - Bash (>= 4.0)
 
+## 並列実行
+
+vibemux は「最初の1画面を立てる道具」です。並列エージェント時代でも役割は変わらず、並列の管理・集約には踏み込みません。詳細な決定経緯は [#30](https://github.com/hirokimry/vibemux/issues/30) を参照してください。
+
+### 役割分担
+
+| 粒度 | 起動主体 | 操作 | 内容 |
+|---|---|---|---|
+| **タブ（フルワークスペース）** | ユーザー | 新タブ → `vibemux new <project>` | vibemux のデフォルトレイアウト（shell + lazygit を中心としたワークスペース）が丸ごと立つ |
+| **ペイン（軽量並列）** | AI エージェント | ペイン追加 + worktree 分離 | shell のみ。lazygit は元の 1 インスタンスを共有 |
+
+- **タブ = 人間の境界**: フルワークスペースが欲しい時はユーザーがタブを作って `vibemux new`
+- **ペイン = AI の境界**: AI が自律的に worktree を切ってペインを追加する
+- **lazygit = 共有の検証手段**: 1 インスタンスで Worktrees タブから `<space>` キーで worktree を切替し、各 worktree の変更を確認する
+
+### vibemux の責務
+
+vibemux が並列時代に提供するのは以下のみです。
+
+- ✅ `vibemux new` で初期 1 画面を立てる
+- ✅ tmux ラッパー（PATH shim）で AI が tmux を壊さないガードレールを提供する
+- ❌ 並列エージェントの管理・集約・命名・終了には関与しない
+
+並列の起動・終了は tmux と git のネイティブ機能（`tmux new-window`、`tmux split-window`、`git worktree add`、`git worktree remove`）に委ねます。
+
 ## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ vibemux は「最初の1画面を立てる道具」です。並列エージェ�
 vibemux が並列時代に提供するのは以下のみです。
 
 - ✅ `vibemux new` で初期 1 画面を立てる
-- ✅ tmux ラッパー（PATH shim）で AI が tmux を壊さないガードレールを提供する
+- 🚧 tmux ラッパー（PATH shim）で AI が tmux を壊さないガードレール（[#31](https://github.com/hirokimry/vibemux/issues/31) で実装予定）
 - ❌ 並列エージェントの管理・集約・命名・終了には関与しない
 
 並列の起動・終了は tmux と git のネイティブ機能（`tmux new-window`、`tmux split-window`、`git worktree add`、`git worktree remove`）に委ねます。


### PR DESCRIPTION
## Summary

Issue #30（問い4）で確定した「並列エージェント時代の vibemux」の役割分担を README.md に明記する。

- タブ = フルワークスペース（ユーザーが `vibemux new` で起動）
- ペイン = AI 並列（AI がペイン追加 + worktree 分離）
- lazygit は1インスタンスで Worktrees タブから切替確認
- vibemux は並列管理に踏み込まず、ガードレールのみ提供

## 変更内容

`README.md` の `## ライセンス` の直前に `## 並列実行` セクションを追加（追記のみ）。既存セクションは変更していない。

セクション構成:

1. 冒頭文 — vibemux は「最初の1画面を立てる道具」、並列管理には踏み込まない旨
2. 役割分担表 — タブ（ユーザー）／ペイン（AI 並列）の対比
3. lazygit の扱い — 1インスタンス共有、Worktrees タブから `<space>` 切替
4. vibemux の責務 — する／しないリスト
5. 関連リンク — Issue #30

## 表現上の方針

- ペイン数（2ペイン／3ペイン）の断定表現は避けた。vibemux は常に 3 ペインを作るが、`VIBEMUX_PANE_TOP_LEFT` のデフォルトが空のため、ユーザーが意識的に使うのは shell + lazygit の 2 ペイン
- 「vibemux のデフォルトレイアウト（shell + lazygit を中心としたワークスペース）」と表現

## Out of Scope

- 冒頭の3ペイン ASCII 図（`files`/`AI assistant`/`git`）と #45（`VIBEMUX_PANE_TOP_LEFT` デフォルト変更）との整合性は別 Issue で扱う

## Test plan

- [x] `make test` 通過（24/24）
- [ ] CI で `make check`（shellcheck + tests）通過
- [ ] GitHub プレビューで Markdown が正しくレンダリングされる

close https://github.com/hirokimry/vibemux/issues/39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 並列実行ワークフロー向けの追加ドキュメントを公開：初期ワークスペースの作成と役割分担（タブ＝フルワークスペース、AI＝軽量ペイン）を説明します。
  * 共用の確認用UI（lazygit相当）を用いた作業ツリー切替と、tmux/git のネイティブ機能による並列起動/終了管理を案内します。
  * tmux を保護するラッパーの導入方針と運用上の注意点を明記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->