### PR TITLE
📖 docs: specification.md に #30 決着内容を反映

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -191,10 +191,10 @@ vibemux は AI エージェントの tmux 操作が破壊的にならないよ�
 
 ### 位置づけ
 
-- **目的**: AI が誤って `kill-server` 等の破壊的コマンドを発行しても、ユーザーのフローを毀損しないようブロックする
-- **実装**: PATH shim（`$PATH` 先頭に置く tmux ラッパー）で、許可リストを通過したコマンドのみ本物の tmux に委譲する
+- **目的**: AI の破壊的 tmux 操作を抑止する。Phase A では検知と警告を行い、Phase B で条件付きブロックを行う
+- **実装**: PATH shim（`$PATH` 先頭に置く tmux ラッパー）を第1段として導入し、許可リスト判定と経路識別（shim/direct）を行う
 - **ツール非依存**: Claude Code 固有の `permissions.deny` には依存しない（`MVV.md` Value #3「道具に縛られない」準拠）。Aider・Cursor・他の CLI エージェントでも同じガードレールが機能する
-- **段階的防御**: 絶対パス直叩き等の bypass は2段階防御モデル（Phase A: 事後検知、Phase B: sandbox 統合）で対処する
+- **段階的防御**: 絶対パス直叩き等の bypass は2段階防御モデルで対処する（Phase A: 事後検知・警告のみ / Phase B: sandbox 統合時に条件付きブロック）
 
 ### 関連
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,10 +1,79 @@
 # vibemux プロダクト仕様書
 
 > このドキュメントはプロダクトの公式仕様を定義する Source of Truth です。
+> 関連: [Issue #30](https://github.com/hirokimry/vibemux/issues/30)（プロダクト方向性の決着） / [`MVV.md`](../MVV.md)
 
 ## 概要
 
-vibemux は tmux ベースのバイブコーディングワークスペースランチャー。単一の bash スクリプトで構成され、コマンドひとつで3ペイン開発環境を立ち上げる。
+vibemux は **「最初の1画面を立てる道具」** である。`vibemux new <session>` のコマンドひとつで、AI と人が同じ画面で開発するための tmux ワークスペースを立ち上げる。
+
+```text
+┌──────────┬─────────────────────┐
+│          │                     │
+│ lazygit  │       shell         │
+│          │                     │
+└──────────┴─────────────────────┘
+```
+
+shell で AI に指示を出し、lazygit で変更を検証する。**この2ペインが、AI 駆動開発における人間の主要活動をカバーする。**
+
+> 内部構造は3ペイン分割を維持しており、左上ペイン (`top-left`) はデフォルトで空シェル、任意のコマンド（例: yazi）を `VIBEMUX_PANE_TOP_LEFT` で差し込めば opt-in 利用も可能。詳細は [§機能仕様 > ペインレイアウト](#ペインレイアウト) を参照。
+
+## vibemux の責務境界
+
+vibemux は AI 駆動・並列エージェント時代でも「最初の1画面を立てる道具」である。これは **積極的な境界設定** であり、`MVV.md` Value #3「道具に縛られない」を実現するための選択である。
+
+### する
+
+| 項目 | 説明 |
+|---|---|
+| コマンド1本でセッションを立てる | `vibemux new <name>` で初期環境が整う |
+| 推奨レイアウトを提示する | shell + lazygit の2ペインデフォルトを提供する |
+| AI が tmux を壊さないガードレールを提供する | PATH shim による禁止コマンドのブロック（[§ガードレール](#ガードレール)） |
+| どのエージェントでも動く環境を作る | Claude Code・Aider・Cursor 等に依存しない |
+
+### しない
+
+| 項目 | 委譲先 |
+|---|---|
+| 並列エージェントの管理・集約 | tmux ネイティブ（タブ・ペイン）と AI エージェントの自律性 |
+| セッションの命名・識別・終了 | ユーザーと tmux のネイティブコマンド |
+| AI の監視・モニタリング | 人間の目視 + 各エージェントが提供するログ・通知 |
+| 特定ツールへの依存実装 | エージェント側の実装に委ねる |
+
+### 「しない」を選ぶ理由
+
+管理機能を抱えれば、特定の並列モデル・命名規則・エージェントに依存した道具となる。これは `MVV.md` Value #3「道具に縛られない」に反するため、これらを担わない。
+
+vibemux は **「場を作る道具」** であり、**「場を運用する道具」ではない**。Mission「ターミナルを、バイブコーディングの最高の場にする」に基づき、最初の1画面を立てる責務に集中する。
+
+## 推奨実行環境
+
+`MVV.md` および [Issue #30](https://github.com/hirokimry/vibemux/issues/30) の決着により、AI 駆動開発の実行基盤として **Ghostty + tmux** を推奨する。VSCode は diff 確認専用に位置づけを格下げした。
+
+| 採用 | 環境 | 用途 |
+|---|---|---|
+| ✅ | Ghostty + tmux | メイン実行基盤（vibemux の前提環境） |
+| 🔽 | VSCode + Claude Code 拡張 | diff 確認専用 |
+| 🔽 | Claude リモートモード | モニタリング補助 |
+
+### Ghostty + tmux
+
+> 詳細は Issue [#42](https://github.com/hirokimry/vibemux/issues/42) で追記される。
+
+長時間ループの detach 対応、並列ペイン管理、Rust 製で軽量、といった観点から個人開発・チーム開発ともにメイン実行基盤として採用する。
+
+### VSCode の位置づけ
+
+> 詳細は Issue [#40](https://github.com/hirokimry/vibemux/issues/40) で追記される。
+
+AI が 100% コードを書く前提では LSP 等のリッチエディタ機能の価値が低下する。VSCode は daily driver から外し、diff 確認専用ツールとして位置づける。
+
+### vibemux のポジショニング
+
+> 詳細は Issue [#41](https://github.com/hirokimry/vibemux/issues/41) で追記される。
+
+vibemux は AI 駆動開発における実行環境を再定義する存在であり、エディタ中心の旧来開発フローから、ターミナル + 並列エージェントを軸とする新しい開発フローへの転換を支える基盤である。
 
 ## 機能仕様
 
@@ -12,28 +81,50 @@ vibemux は tmux ベースのバイブコーディングワークスペースラ
 
 | サブコマンド | 説明 |
 |---|---|
-| `vibemux new <session> [dir]` | 3ペインセッションを新規作成 |
+| `vibemux new <session> [dir]` | 新規セッションを作成 |
 | `vibemux attach <session>` | 既存セッションにアタッチ |
 | `vibemux list` | アクティブなセッション一覧 |
 | `vibemux version` | バージョン表示 |
 
 ### ペインレイアウト
 
+デフォルトは **2ペイン構成**（lazygit + shell）である。Issue #30（問い3）の検証に基づき、yazi（ファイルマネージャ）はデフォルトから廃止された。
+
 ```text
 ┌──────────┬─────────────────────┐
 │ top-left │                     │
-│  (0.0)   │       right         │
-├──────────┤       (0.2)         │
+│ (empty)  │       right         │
+├──────────┤      (shell)        │
 │ bot-left │                     │
-│  (0.1)   │                     │
+│ (lazygit)│                     │
 └──────────┴─────────────────────┘
 ```
 
-tmux の分割順序により、ペインインデックスは以下の通り固定される:
+#### 構造詳細
+
+tmux の split-window により内部的には3ペイン構造を維持する。`top-left` はデフォルトで空シェルとなり、視覚的には2ペイン UX として動作する。
+
+ペインインデックスの割り当て順序:
 
 1. `new-session` で最初のペイン作成 → index 0（後の top-left）
-2. `split-window -h` で右ペイン分割 → index 0 が左、新ペインが右（index 2 に移動）
+2. `split-window -h` で右ペイン分割 → 右ペインが index 2
 3. `split-window -v -t 0.0` で左を上下分割 → top-left が 0.0、bottom-left が 0.1
+
+#### yazi デフォルト廃止の経緯
+
+[Issue #30](https://github.com/hirokimry/vibemux/issues/30)（問い3）の検証で、ファイルツリーは AI 駆動開発において主役にも準主役にもならないと判定された。
+
+- AI が 100% 書く前提では、ファイル構造の探索を AI に依頼する方が高速
+- 変更ファイル一覧は lazygit が既にカバーしている
+- ファウンダーの実行動でも、yazi が見られる頻度は稀であった
+
+このため `VIBEMUX_PANE_TOP_LEFT` のデフォルトを空シェルに変更した。yazi を引き続き使いたい場合は環境変数で復元できる:
+
+```bash
+VIBEMUX_PANE_TOP_LEFT=yazi vibemux new myproject
+```
+
+> なお `MVV.md` Value #2「ファイル・git・AIが常に視界にある」の「ファイル」の定義見直しはファウンダー判断事項として継続検討中である。本仕様書では yazi デフォルト廃止という決定事項のみを記述する。
 
 ### 設定
 
@@ -47,7 +138,7 @@ tmux の分割順序により、ペインインデックスは以下の通り固
 
 | 変数 | 説明 | デフォルト |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | *(シェル)* |
+| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | *(空シェル — yazi 等を opt-in 可能。経緯は [§ペインレイアウト](#ペインレイアウト))* |
 | `VIBEMUX_PANE_BOTTOM_LEFT` | 左下ペインのコマンド | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | 右ペインのコマンド | *(シェル)* |
 | `VIBEMUX_RIGHT_RATIO` | 右ペインの幅 (%) | `70` |
@@ -59,11 +150,62 @@ tmux の分割順序により、ペインインデックスは以下の通り固
 - 二重起動防止: `$TMUX` 環境変数による tmux ネスト検知
 - セッション重複防止: 同名セッション存在時のエラー通知
 
+## 並列エージェント時代の vibemux
+
+並列エージェント実行時代でも、vibemux の役割は変わらない。最初の1画面を立てる責務に集中し、並列の起動・管理・終了は tmux と AI エージェントの自律性に委ねる。
+
+### vibemux が管理しないもの
+
+| 領域 | 委譲先 |
+|---|---|
+| **並列エージェントの管理・集約** | tmux ネイティブ（タブ追加・ペイン分割）と AI エージェントの自律的な並列化 |
+| **セッションの命名・識別・終了** | ユーザーが `vibemux new <name>` で命名し、終了は `tmux kill-session` / 全ペイン exit / `git worktree remove` |
+| **AI の監視・モニタリング** | 各エージェントが提供するログ・通知・人間の目視（lazygit 等） |
+
+### 並列時の役割分担
+
+並列化が起きるとき、粒度に応じて主体が分かれる。
+
+| 粒度 | 主体 | 操作 | 環境 |
+|---|---|---|---|
+| **タブ（フルワークスペース）** | ユーザー | 新タブで `vibemux new` | 2ペイン（shell + lazygit）が丸ごと立つ |
+| **ペイン（軽量並列）** | AI エージェント | ペイン追加 + worktree 分離 | shell のみ。lazygit は元の1個で worktree 切替 |
+
+`vibemux window` のような中間コマンドは **設けない**。タブ内の並列化は AI + tmux ネイティブの責務である。
+
+### セッションのライフサイクル
+
+vibemux は永続的な状態を持たない（DB なし・常駐プロセスなし）。終了・クリーンアップは生成元のネイティブコマンドに委ねる。
+
+| リソース | 生成 | 終了 |
+|---|---|---|
+| tmux セッション | `vibemux new` | `tmux kill-session` / 全ペイン exit |
+| AI が追加したペイン | AI（`split-window`） | `exit` でペイン消滅 |
+| AI が作った worktree | AI（`git worktree add`） | `git worktree remove` |
+
+`vibemux kill` のような終了コマンドは提供しない。
+
+## ガードレール
+
+vibemux は AI エージェントの tmux 操作が破壊的にならないよう、PATH shim ベースのガードレールを提供する。詳細設計は [`docs/tmux-guardrail.md`](./tmux-guardrail.md) に記載する。
+
+### 位置づけ
+
+- **目的**: AI が誤って `kill-server` 等の破壊的コマンドを発行しても、ユーザーのフローを毀損しないようブロックする
+- **実装**: PATH shim（`$PATH` 先頭に置く tmux ラッパー）で、許可リストを通過したコマンドのみ本物の tmux に委譲する
+- **ツール非依存**: Claude Code 固有の `permissions.deny` には依存しない（`MVV.md` Value #3「道具に縛られない」準拠）。Aider・Cursor・他の CLI エージェントでも同じガードレールが機能する
+- **段階的防御**: 絶対パス直叩き等の bypass は2段階防御モデル（Phase A: 事後検知、Phase B: sandbox 統合）で対処する
+
+### 関連
+
+- [`docs/tmux-guardrail.md`](./tmux-guardrail.md) — ガードレール設計の Source of Truth
+- [`docs/tmux-kill-session-identification.md`](./tmux-kill-session-identification.md) — `kill-session` の自セッション識別方式
+
 ## 非機能要件
 
 ### セキュリティ
 
-詳細は `SECURITY.md` を参照。
+詳細は [`docs/SECURITY.md`](./SECURITY.md) を参照。
 
 ## 開発ワークフロー
 
@@ -83,3 +225,11 @@ tmux の分割順序により、ペインインデックスは以下の通り固
 2. コミット時: pre-commit フックが自動実行（シークレット検知、shellcheck）
 3. プッシュ時: pre-push フックが自動実行（全ファイル shellcheck、必須ファイル確認）
 4. CI: GitHub Actions で `make check` を実行
+
+## 参照
+
+- [`MVV.md`](../MVV.md) — 全判断の最上位基準
+- [Issue #30](https://github.com/hirokimry/vibemux/issues/30) — vibemux プロダクト方向性の再検証（4問の決着）
+- [`docs/tmux-guardrail.md`](./tmux-guardrail.md) — ガードレール設計
+- [`docs/design-philosophy.md`](./design-philosophy.md) — 設計思想
+- [`docs/SECURITY.md`](./SECURITY.md) — セキュリティ仕様


### PR DESCRIPTION
## 概要

Issue #30 の4つの問いの決着内容を `docs/specification.md` に反映する。SoT 仕様書として責務境界・並列エージェント時代の立ち位置・ガードレール位置づけ・レイアウト変更を明記し、後続 Issue (#40 / #41 / #42) が並列追記できる骨格を整える。

## 主な変更内容

- **概要書き換え**: 「最初の1画面を立てる道具」コンセプトを明文化
- **責務境界 (新設)**: する / しない の table と「しない」を選ぶ理由
- **推奨実行環境 (新設)**: Ghostty + tmux / VSCode / vibemux ポジショニングの3小見出し（#42 / #40 / #41 のスタブ）
- **ペインレイアウト書き換え**: 2ペインデフォルト UX + 内部3ペイン構造の説明 + yazi デフォルト廃止の経緯
- **設定 table 更新**: `VIBEMUX_PANE_TOP_LEFT` のデフォルト記述を「空シェル — yazi 等を opt-in 可能」に
- **並列エージェント時代の vibemux (新設)**: 管理しない領域・並列時の役割分担・セッションのライフサイクル
- **ガードレール (新設)**: PATH shim の位置づけ + `docs/tmux-guardrail.md` へのリンク
- **参照セクション追加**: MVV.md / Issue #30 / tmux-guardrail.md / design-philosophy.md / SECURITY.md

## 後続 Issue との関係

SM 並列実行判定（`.claude/knowledge/sm/decisions/2026-Q2.md`）に従い、本 PR は specification.md の **骨格** を整備する位置づけ。マージ後、以下を並列で追記できる:

- #40 → `### VSCode の位置づけ` 配下
- #41 → `### vibemux のポジショニング` 配下
- #42 → `### Ghostty + tmux` 配下

各 Issue は独立した小見出し配下のみを編集するため衝突しない。

## MVV 整合

- `MVV.md` Value #2「ファイル・git・AI が常に視界にある」の「ファイル」の定義見直しはファウンダー判断事項として継続検討中。本仕様書では yazi デフォルト廃止という決定事項のみを記述（MVV 改訂・改変提案はしない）
- `MVV.md` Value #3「道具に縛られない」: ガードレールが Claude Code 固有の `permissions.deny` に依存しないことを明記

## テスト

- [x] `make test` が PASS（24/24）
- [x] リンク先ファイル (`MVV.md`, `docs/tmux-guardrail.md`, `docs/tmux-kill-session-identification.md`, `docs/SECURITY.md`, `docs/design-philosophy.md`) の存在確認
- [x] `cr review --plain` で 本差分に対する指摘なし（指摘されたのは untracked な別エージェントファイルのみ）
- [x] フェンスコードブロックは全て言語指定あり（`.claude/rules/markdown.md` 準拠）

close #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## ドキュメント更新

* **ドキュメント**
  * 製品定義を全面的に再定義しました（初期 tmux ワークスペースを作る UX に注力）
  * デフォルトを 2 ペイン構成（lazygit + シェル）に変更、トップ左は空のシェルに（必要時は環境変数で有効化）
  * `yazi` をデフォルトから除外、内部的な 3 ペイン構造は UX 用に維持
  * 並列エージェントの役割・伝搬モデルと責任境界を明確化
  * ライフサイクル仕様（永続状態なし、kill 相当の操作非推奨）を追加
  * tmux の破壊的操作を制限する PATH シムによるガードレールを導入
  * セキュリティ参照を docs/SECURITY.md に集約、推奨実行環境を Ghostty + tmux に明記（VSCode/Claude は二次的）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->