### PR TITLE
fix: `make install` でインストール手順を一発化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,17 @@ test:
 check: lint test
 
 install:
-	mkdir -p ~/.local/bin
-	ln -sf "$(CURDIR)/vibemux" ~/.local/bin/vibemux
-	@echo "Installed: ~/.local/bin/vibemux"
+	@mkdir -p ~/.local/bin
+	@ln -sf "$(CURDIR)/vibemux" ~/.local/bin/vibemux
+	@echo "Installed: ~/.local/bin/vibemux -> $(CURDIR)/vibemux"
+	@case ":$$PATH:" in \
+		*":$$HOME/.local/bin:"*) \
+			echo "Ready: run 'vibemux' from anywhere." ;; \
+		*) \
+			echo ""; \
+			echo "WARNING: ~/.local/bin is not in \$$PATH."; \
+			echo "Add the following line to your shell rc file (~/.zshrc, ~/.bashrc):"; \
+			echo ""; \
+			echo "    export PATH=\"\$$HOME/.local/bin:\$$PATH\""; \
+			echo "" ;; \
+	esac

--- a/README.en.md
+++ b/README.en.md
@@ -6,22 +6,19 @@
 
 Vibe coding workspace for tmux.
 
-One command launches a 3-pane tmux session — file manager, git client, and AI coding assistant side by side. Your terminal becomes a fully-equipped vibe coding cockpit.
+One command launches a 2-pane tmux session — git client and AI coding assistant side by side. Your terminal becomes a fully-equipped vibe coding cockpit.
 
 ```text
 ┌──────────┬─────────────────────┐
-│  files   │                     │
-│          │    AI assistant      │
-├──────────┤                     │
-│   git    │                     │
+│          │                     │
+│ lazygit  │    AI assistant     │
+│          │                     │
 └──────────┴─────────────────────┘
 ```
 
 ## Why vibemux?
 
-Vibe coding with Claude Code, Aider, and Copilot CLI works best in the terminal — but you still need quick access to your file tree and git status. Switching between windows breaks your flow.
-
-vibemux gives you everything in one view: navigate files, review diffs, and talk to your AI assistant without leaving the keyboard.
+In AI-driven development, you instruct an agent in the shell and verify changes in lazygit — these two activities cover the human's main work. vibemux puts both in one view so you never break your flow switching windows.
 
 ## Install
 
@@ -49,18 +46,16 @@ Customize pane commands via environment variables or a config file at `~/.config
 
 | Variable | Description | Default |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | Top-left pane command | *(shell)* |
-| `VIBEMUX_PANE_BOTTOM_LEFT` | Bottom-left pane command | `lazygit` |
+| `VIBEMUX_PANE_LEFT` | Left pane command | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | Right pane command | *(shell)* |
 | `VIBEMUX_RIGHT_RATIO` | Right pane width (%) | `70` |
-| `VIBEMUX_FOCUS` | Initial focus: `right`, `top-left`, `bottom-left` | `right` |
+| `VIBEMUX_FOCUS` | Initial focus: `right`, `left` | `right` |
 
 ### Config File
 
 ```bash
 # ~/.config/vibemux/config
-VIBEMUX_PANE_TOP_LEFT="yazi"
-VIBEMUX_PANE_BOTTOM_LEFT="lazygit"
+VIBEMUX_PANE_LEFT="lazygit"
 VIBEMUX_PANE_RIGHT="claude --resume"
 VIBEMUX_RIGHT_RATIO=70
 VIBEMUX_FOCUS=right
@@ -70,24 +65,23 @@ Set `VIBEMUX_CONFIG` to load from a different path.
 
 ### Example Setups
 
-**Claude Code + yazi + lazygit** (recommended):
+**Claude Code + lazygit** (recommended):
 
 ```bash
 VIBEMUX_PANE_RIGHT="claude --resume" vibemux new dev
 ```
 
-**Aider with lf and tig:**
+**Aider + tig:**
 
 ```bash
-VIBEMUX_PANE_TOP_LEFT="lf"
-VIBEMUX_PANE_BOTTOM_LEFT="tig"
+VIBEMUX_PANE_LEFT="tig"
 VIBEMUX_PANE_RIGHT="aider"
 ```
 
 **Minimal — AI assistant only:**
 
 ```bash
-VIBEMUX_PANE_TOP_LEFT="" VIBEMUX_PANE_BOTTOM_LEFT="" VIBEMUX_PANE_RIGHT="claude" vibemux new focus
+VIBEMUX_PANE_LEFT="" VIBEMUX_PANE_RIGHT="claude" vibemux new focus
 ```
 
 ## Contributing

--- a/README.en.md
+++ b/README.en.md
@@ -24,10 +24,13 @@ In AI-driven development, you instruct an agent in the shell and verify changes 
 
 ```bash
 git clone https://github.com/hirokimry/vibemux.git
-ln -s "$(pwd)/vibemux/vibemux" ~/.local/bin/vibemux
+cd vibemux
+make install
 ```
 
-Or just copy the `vibemux` script anywhere on your `$PATH`.
+`make install` creates an absolute-path symlink at `~/.local/bin/vibemux`. If `~/.local/bin` is not on your `$PATH`, the command prints instructions for adding it.
+
+Prefer not to use `make`? Just copy the `vibemux` script anywhere on your `$PATH`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 ```text
 ┌──────────┬─────────────────────┐
-│  shell   │                     │
-│          │       shell         │
-├──────────┤                     │
-│ lazygit  │                     │
+│          │                     │
+│ lazygit  │       shell         │
+│          │                     │
 └──────────┴─────────────────────┘
 ```
 
@@ -47,18 +46,16 @@ vibemux list                       # アクティブなセッション一覧
 
 | 変数 | 説明 | デフォルト |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | *(シェル)* |
-| `VIBEMUX_PANE_BOTTOM_LEFT` | 左下ペインのコマンド | `lazygit` |
+| `VIBEMUX_PANE_LEFT` | 左ペインのコマンド | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | 右ペインのコマンド | *(シェル)* |
 | `VIBEMUX_RIGHT_RATIO` | 右ペインの幅 (%) | `70` |
-| `VIBEMUX_FOCUS` | 起動時のフォーカス: `right`, `top-left`, `bottom-left` | `right` |
+| `VIBEMUX_FOCUS` | 起動時のフォーカス: `right`, `left` | `right` |
 
 ### 設定ファイル
 
 ```bash
 # ~/.config/vibemux/config
-VIBEMUX_PANE_TOP_LEFT="yazi"
-VIBEMUX_PANE_BOTTOM_LEFT="lazygit"
+VIBEMUX_PANE_LEFT="lazygit"
 VIBEMUX_PANE_RIGHT="claude --resume"
 VIBEMUX_RIGHT_RATIO=70
 VIBEMUX_FOCUS=right
@@ -68,24 +65,23 @@ VIBEMUX_FOCUS=right
 
 ### 設定例
 
-**Claude Code + yazi + lazygit**（おすすめ）:
+**Claude Code + lazygit**（おすすめ）:
 
 ```bash
 VIBEMUX_PANE_RIGHT="claude --resume" vibemux new dev
 ```
 
-**Aider + lf + tig:**
+**Aider + tig:**
 
 ```bash
-VIBEMUX_PANE_TOP_LEFT="lf"
-VIBEMUX_PANE_BOTTOM_LEFT="tig"
+VIBEMUX_PANE_LEFT="tig"
 VIBEMUX_PANE_RIGHT="aider"
 ```
 
 **ミニマル構成 — AI アシスタントのみ:**
 
 ```bash
-VIBEMUX_PANE_TOP_LEFT="" VIBEMUX_PANE_BOTTOM_LEFT="" VIBEMUX_PANE_RIGHT="claude" vibemux new focus
+VIBEMUX_PANE_LEFT="" VIBEMUX_PANE_RIGHT="claude" vibemux new focus
 ```
 
 ## コントリビュート

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ AI 駆動開発では、shell でエージェントに指示を出し、lazygit 
 
 ```bash
 git clone https://github.com/hirokimry/vibemux.git
-ln -s "$(pwd)/vibemux/vibemux" ~/.local/bin/vibemux
+cd vibemux
+make install
 ```
 
-または `vibemux` スクリプトを `$PATH` の通った場所にコピーするだけでも OK です。
+`make install` は `~/.local/bin/vibemux` に絶対パスでシンボリックリンクを作成します。`~/.local/bin` が `$PATH` に含まれない場合は、追加方法を案内します。
+
+`make` を使いたくない場合は、`vibemux` スクリプトを `$PATH` の通った場所に直接コピーしても動きます。
 
 ## 使い方
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -17,7 +17,7 @@ vibemux は **「最初の1画面を立てる道具」** である。`vibemux ne
 
 shell で AI に指示を出し、lazygit で変更を検証する。**この2ペインが、AI 駆動開発における人間の主要活動をカバーする。**
 
-> 内部構造は3ペイン分割を維持しており、左上ペイン (`top-left`) はデフォルトで空シェル、任意のコマンド（例: yazi）を `VIBEMUX_PANE_TOP_LEFT` で差し込めば opt-in 利用も可能。詳細は [§機能仕様 > ペインレイアウト](#ペインレイアウト) を参照。
+> 内部構造も2ペインで完結する（旧仕様の3ペイン構造は Issue #32 で廃止）。詳細は [§機能仕様 > ペインレイアウト](#ペインレイアウト) を参照。
 
 ## vibemux の責務境界
 
@@ -191,43 +191,34 @@ vibemux 自身は管理機能を持たない（[§vibemux の責務境界](#vibe
 
 ### ペインレイアウト
 
-デフォルトは **2ペイン構成**（lazygit + shell）である。Issue #30（問い3）の検証に基づき、yazi（ファイルマネージャ）はデフォルトから廃止された。
+デフォルトは **2ペイン構成**（lazygit + shell）である。Issue #30（問い3）の検証に基づき yazi（ファイルマネージャ）デフォルトを廃止し、Issue #32 で内部構造の3ペインも撤廃して2ペインに統一した。
 
 ```text
 ┌──────────┬─────────────────────┐
-│ top-left │                     │
-│ (empty)  │       right         │
-├──────────┤      (shell)        │
-│ bot-left │                     │
-│ (lazygit)│                     │
+│          │                     │
+│ left     │       right         │
+│ (lazygit)│      (shell)        │
+│          │                     │
 └──────────┴─────────────────────┘
 ```
 
 #### 構造詳細
 
-tmux の split-window により内部的には3ペイン構造を維持する。`top-left` はデフォルトで空シェルとなり、視覚的には2ペイン UX として動作する。
+tmux の split-window で `-h`（水平分割）を1回だけ行う2ペイン構造である。
 
 ペインインデックスの割り当て順序:
 
-1. `new-session` で最初のペイン作成 → index 0（後の top-left）
-2. `split-window -h` で右ペイン分割 → 右ペインが index 2
-3. `split-window -v -t 0.0` で左を上下分割 → top-left が 0.0、bottom-left が 0.1
+1. `new-session` で最初のペイン作成 → index 0（left）
+2. `split-window -h` で右ペイン分割 → right が index 1
 
-#### yazi デフォルト廃止の経緯
+#### 旧3ペイン構造の廃止経緯
 
-[Issue #30](https://github.com/hirokimry/vibemux/issues/30)（問い3）の検証で、ファイルツリーは AI 駆動開発において主役にも準主役にもならないと判定された。
+旧仕様では `split-window -v` により左ペインを上下分割した内部3ペイン構造を取っていた（top-left を空シェルにすることで視覚的には2ペインに見せる方式）。Issue #32 でこの内部分割を撤廃し、コード・UX 双方を2ペインに揃えた。
 
-- AI が 100% 書く前提では、ファイル構造の探索を AI に依頼する方が高速
-- 変更ファイル一覧は lazygit が既にカバーしている
-- ファウンダーの実行動でも、yazi が見られる頻度は稀であった
+- yazi デフォルト廃止（[Issue #30](https://github.com/hirokimry/vibemux/issues/30) 問い3）により top-left ペインの存在意義が失われたため
+- 内部だけ3ペインを残すと設定変数（`VIBEMUX_PANE_TOP_LEFT`）・フォーカス値・ドキュメントが冗長になり、`MVV.md` Value #1「一発で整う」に反するため
 
-このため `VIBEMUX_PANE_TOP_LEFT` のデフォルトを空シェルに変更した。yazi を引き続き使いたい場合は環境変数で復元できる:
-
-```bash
-VIBEMUX_PANE_TOP_LEFT=yazi vibemux new myproject
-```
-
-> なお `MVV.md` Value #2「ファイル・git・AIが常に視界にある」の「ファイル」の定義見直しはファウンダー判断事項として継続検討中である。本仕様書では yazi デフォルト廃止という決定事項のみを記述する。
+> なお `MVV.md` Value #2「ファイル・git・AIが常に視界にある」の「ファイル」の定義見直しはファウンダー判断事項として継続検討中である。本仕様書では yazi デフォルト廃止と2ペイン化という決定事項のみを記述する。
 
 ### 設定
 
@@ -241,11 +232,10 @@ VIBEMUX_PANE_TOP_LEFT=yazi vibemux new myproject
 
 | 変数 | 説明 | デフォルト |
 |---|---|---|
-| `VIBEMUX_PANE_TOP_LEFT` | 左上ペインのコマンド | *(空シェル — yazi 等を opt-in 可能。経緯は [§ペインレイアウト](#ペインレイアウト))* |
-| `VIBEMUX_PANE_BOTTOM_LEFT` | 左下ペインのコマンド | `lazygit` |
+| `VIBEMUX_PANE_LEFT` | 左ペインのコマンド | `lazygit` |
 | `VIBEMUX_PANE_RIGHT` | 右ペインのコマンド | *(シェル)* |
 | `VIBEMUX_RIGHT_RATIO` | 右ペインの幅 (%) | `70` |
-| `VIBEMUX_FOCUS` | 初期フォーカス | `right` |
+| `VIBEMUX_FOCUS` | 初期フォーカス（`right`, `left`） | `right` |
 | `VIBEMUX_CONFIG` | 設定ファイルパス | `~/.config/vibemux/config` |
 
 ### 補助機能

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -uo pipefail
+
+# Tests for `make install` target.
+# Uses a temporary HOME so the user's real ~/.local/bin is not touched.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+passed=0
+failed=0
+
+pass() { echo "  PASS: $1"; ((passed++)); }
+fail() { echo "  FAIL: $1"; ((failed++)); }
+
+echo "=== install test suite ==="
+echo
+
+if ! command -v make >/dev/null 2>&1; then
+  echo "  SKIP: make not available"
+  exit 0
+fi
+
+if [[ ! -f "$REPO_ROOT/Makefile" ]]; then
+  fail "Makefile not found at repo root"
+  exit 1
+fi
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "$TMPHOME"' EXIT
+
+# Run install with isolated HOME (and a PATH that lacks ~/.local/bin).
+install_output="$(HOME="$TMPHOME" PATH="/usr/bin:/bin" make -C "$REPO_ROOT" install 2>&1)" || {
+  fail "make install exited non-zero"
+  echo "$install_output"
+  exit 1
+}
+
+# 1. Symlink exists.
+symlink="$TMPHOME/.local/bin/vibemux"
+if [[ -L "$symlink" ]]; then
+  pass "symlink created at \$HOME/.local/bin/vibemux"
+else
+  fail "symlink not created at \$HOME/.local/bin/vibemux"
+  echo "$install_output"
+  exit 1
+fi
+
+# 2. Symlink target is an absolute path.
+target="$(readlink "$symlink")"
+if [[ "$target" = /* ]]; then
+  pass "symlink target is an absolute path"
+else
+  fail "symlink target is relative: $target"
+fi
+
+# 3. Symlink points to the repo's vibemux script.
+if [[ "$target" = "$REPO_ROOT/vibemux" ]]; then
+  pass "symlink resolves to repo's vibemux script"
+else
+  fail "symlink target mismatch: got '$target', want '$REPO_ROOT/vibemux'"
+fi
+
+# 4. The symlink is executable end-to-end.
+if "$symlink" help >/dev/null 2>&1; then
+  pass "vibemux runs through the installed symlink"
+else
+  fail "vibemux help exited non-zero through the symlink"
+fi
+
+# 5. PATH warning is printed when ~/.local/bin is missing from PATH.
+if echo "$install_output" | grep -q "WARNING: ~/.local/bin is not in"; then
+  pass "warns when ~/.local/bin is not in PATH"
+else
+  fail "missing PATH warning when ~/.local/bin not in PATH"
+fi
+
+# 6. Idempotency: running install again should still leave a working symlink.
+HOME="$TMPHOME" PATH="/usr/bin:/bin" make -C "$REPO_ROOT" install >/dev/null 2>&1 || {
+  fail "second make install failed"
+  exit 1
+}
+if [[ -L "$symlink" ]] && [[ "$(readlink "$symlink")" = "$REPO_ROOT/vibemux" ]]; then
+  pass "install is idempotent"
+else
+  fail "install is not idempotent"
+fi
+
+# 7. PATH-included branch reports ready.
+ready_output="$(HOME="$TMPHOME" PATH="$TMPHOME/.local/bin:/usr/bin:/bin" make -C "$REPO_ROOT" install 2>&1)" || {
+  fail "make install exited non-zero with PATH set"
+  exit 1
+}
+if echo "$ready_output" | grep -q "Ready: run 'vibemux' from anywhere"; then
+  pass "reports ready when ~/.local/bin is in PATH"
+else
+  fail "missing ready message when ~/.local/bin is in PATH"
+fi
+
+echo
+echo "Result: $passed passed, $failed failed"
+[[ "$failed" -eq 0 ]]

--- a/tests/test_vibemux.sh
+++ b/tests/test_vibemux.sh
@@ -102,7 +102,8 @@ echo
 
 # ── Environment Variable Defaults ────────────────────────────
 echo "[env var defaults]"
-assert_output_contains "usage shows VIBEMUX_PANE_TOP_LEFT" "VIBEMUX_PANE_TOP_LEFT" "$VIBEMUX" help
+assert_output_contains "usage shows VIBEMUX_PANE_LEFT" "VIBEMUX_PANE_LEFT" "$VIBEMUX" help
+assert_output_contains "usage shows VIBEMUX_PANE_RIGHT" "VIBEMUX_PANE_RIGHT" "$VIBEMUX" help
 assert_output_contains "usage shows VIBEMUX_CONFIG" "VIBEMUX_CONFIG" "$VIBEMUX" help
 echo
 

--- a/vibemux
+++ b/vibemux
@@ -4,8 +4,7 @@ set -euo pipefail
 VERSION="0.1.0"
 
 # ── Configuration ──────────────────────────────────────────────
-VIBEMUX_PANE_TOP_LEFT="${VIBEMUX_PANE_TOP_LEFT:-}"
-VIBEMUX_PANE_BOTTOM_LEFT="${VIBEMUX_PANE_BOTTOM_LEFT:-lazygit}"
+VIBEMUX_PANE_LEFT="${VIBEMUX_PANE_LEFT:-lazygit}"
 VIBEMUX_PANE_RIGHT="${VIBEMUX_PANE_RIGHT:-}"
 VIBEMUX_RIGHT_RATIO="${VIBEMUX_RIGHT_RATIO:-70}"
 VIBEMUX_FOCUS="${VIBEMUX_FOCUS:-right}"
@@ -23,25 +22,23 @@ usage() {
 vibemux $VERSION - Vibe coding workspace for tmux
 
 Usage:
-  vibemux new <session-name> [directory]   Create a new 3-pane session
+  vibemux new <session-name> [directory]   Create a new 2-pane session
   vibemux attach <session-name>            Attach to an existing session
   vibemux list                             List active sessions
   vibemux version                          Show version
 
 Layout:
   ┌──────────┬─────────────────────┐
-  │ top-left │                     │
-  │          │       right         │
-  ├──────────┤                     │
-  │ bot-left │                     │
+  │          │                     │
+  │ lazygit  │       shell         │
+  │          │                     │
   └──────────┴─────────────────────┘
 
 Configuration (environment variables):
-  VIBEMUX_PANE_TOP_LEFT      Command for top-left pane     (default: shell)
-  VIBEMUX_PANE_BOTTOM_LEFT   Command for bottom-left pane  (default: lazygit)
-  VIBEMUX_PANE_RIGHT         Command for right pane        (default: shell)
+  VIBEMUX_PANE_LEFT          Command for left pane          (default: lazygit)
+  VIBEMUX_PANE_RIGHT         Command for right pane         (default: shell)
   VIBEMUX_RIGHT_RATIO        Right pane width percentage    (default: 70)
-  VIBEMUX_FOCUS              Initial focus: right|top-left|bottom-left (default: right)
+  VIBEMUX_FOCUS              Initial focus: right|left      (default: right)
   VIBEMUX_CONFIG             Path to config file            (default: ~/.config/vibemux/config)
 EOF
 }
@@ -53,9 +50,8 @@ die() {
 
 resolve_focus_pane() {
   case "$VIBEMUX_FOCUS" in
-    top-left)    echo "0.0" ;;
-    bottom-left) echo "0.1" ;;
-    right|*)     echo "0.2" ;;
+    left)    echo "0.0" ;;
+    right|*) echo "0.1" ;;
   esac
 }
 
@@ -71,15 +67,13 @@ cmd_new() {
 
   tmux has-session -t "$session" 2>/dev/null && die "session '$session' already exists (use 'vibemux attach $session')"
 
-  # Build 3-pane layout
+  # Build 2-pane layout
   tmux new-session -d -s "$session" -c "$dir"
   tmux split-window -h -l "${VIBEMUX_RIGHT_RATIO}%" -t "$session" -c "$dir"
-  tmux split-window -v -t "$session:0.0" -c "$dir"
 
-  # Launch commands (pane indices: 0=top-left, 1=bottom-left, 2=right)
-  [[ -n "$VIBEMUX_PANE_TOP_LEFT" ]]     && tmux send-keys -t "$session:0.0" "$VIBEMUX_PANE_TOP_LEFT" C-m
-  [[ -n "$VIBEMUX_PANE_BOTTOM_LEFT" ]]  && tmux send-keys -t "$session:0.1" "$VIBEMUX_PANE_BOTTOM_LEFT" C-m
-  [[ -n "$VIBEMUX_PANE_RIGHT" ]]        && tmux send-keys -t "$session:0.2" "$VIBEMUX_PANE_RIGHT" C-m
+  # Launch commands (pane indices: 0=left, 1=right)
+  [[ -n "$VIBEMUX_PANE_LEFT" ]]  && tmux send-keys -t "$session:0.0" "$VIBEMUX_PANE_LEFT" C-m
+  [[ -n "$VIBEMUX_PANE_RIGHT" ]] && tmux send-keys -t "$session:0.1" "$VIBEMUX_PANE_RIGHT" C-m
 
   tmux select-pane -t "$session:$(resolve_focus_pane)"
   tmux attach -t "$session"


### PR DESCRIPTION
## 概要

Issue #65 の対応。README の `ln -s "$(pwd)/vibemux/vibemux" ~/.local/bin/vibemux` は実行ディレクトリ依存で壊れやすく、`~/.local/bin` が `$PATH` に無い環境では `command not found` になる。MVV Value #1「一発で整う」に違反していた。

## 変更内容

- **README.md / README.en.md**: インストール手順を `git clone && cd vibemux && make install` の3ステップに変更。`make install` の挙動（絶対パスでのシンボリックリンク作成・PATH 案内）を明記。
- **Makefile**: `install` ターゲットを強化。
  - `$(CURDIR)` で常に絶対パスのシンボリックリンクを作成（既存挙動）
  - `~/.local/bin` が `$PATH` に含まれない場合は WARNING と修正方法を出力
  - `$PATH` に含まれている場合は "Ready: run 'vibemux' from anywhere." と案内
- **tests/test_install.sh**: 新規。隔離した `HOME` で `make install` を検証。
  - シンボリックリンクの存在・絶対パス性・正しいターゲット
  - シンボリックリンク経由で `vibemux help` が動作
  - PATH 未設定時の WARNING、PATH 設定時の Ready メッセージ
  - 冪等性（2回実行しても壊れない）

## 検証

- `make check` 全 PASS（shellcheck + 既存 75 + 25 件 + 新規 7 件 = 107 件）
- ローカル実行で WARNING / Ready 両ブランチの出力を確認

## なぜこの設計か

- `make install` は標準的なフローで、`$(CURDIR)` により実行ディレクトリ非依存。
- vibemux は単一の bash スクリプトのため、独自インストーラーは過剰。Makefile の既存ターゲットを強化するに留めた。
- PATH 警告を出すことで、ユーザーが symlink 作成後すぐに `vibemux` を実行できる状態に到達できる（"一発で整う"）。

close https://github.com/hirokimry/vibemux/issues/65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レイアウトを3ペイン（左上/左下/右）から2ペイン（左/右）に変更し、左ペインのデフォルトをlazygitに設定

* **改善**
  * インストール方法を `make install` コマンドに統一し、PATH自動検出を追加

* **ドキュメント**
  * インストール手順と設定オプションを更新（`VIBEMUX_PANE_LEFT` に統合）
  * 仕様書を2ペイン構造に合わせて改訂

* **テスト**
  * インストールプロセスの包括的なテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->